### PR TITLE
Automate package building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.zip
 *.nupkg
 LICENSE.txt
+out

--- a/Build-Package.ps1
+++ b/Build-Package.ps1
@@ -1,0 +1,84 @@
+param ([string] $version, [string] $output)
+$ErrorActionPreference = "Stop"
+
+If ( $version -eq "" ) {
+	Write-Error "No version parameter was passed in."
+	Exit 1
+}
+
+$SOURCE = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+If ( $output -eq "" ) {
+	$output = "$SOURCE\out"
+}
+
+$file32 = "haxe-$version-win.zip"
+$file64 = "haxe-$version-win64.zip"
+
+Function Clear-Output {
+	If ( Test-Path -Path $OUTPUT) {
+		Get-ChildItem -Path $OUTPUT -File | foreach { $_.Delete()} # delete all contents
+	} Else {
+		New-Item -Path $OUTPUT -ItemType "directory" -Force > $null # Create empty
+	}
+}
+
+Function Copy-File {
+	param ([string] $file)
+	Write-Host "Copying $file"
+	Copy-Item $file $OUTPUT
+}
+
+Function Copy-Binaries {
+	# Copy over zipped up binaries
+	ForEach ($file in @("$SOURCE\$file32", "$SOURCE\$file64")) {
+		If ( ! (Test-Path -Path $file -PathType Leaf) ) {
+			Write-Error "File $file missing"
+			Exit 2
+		}
+		Copy-File $file
+	}
+}
+
+Function Write-InstallScript {
+	# Generate install script
+	Write-Host "Generating install script"
+
+	# Load template
+	$template = (Get-Content -Path "$SOURCE\chocolateyInstall.ps1" -Raw)
+
+	# Get checksums
+	$checksum32 = (Get-FileHash $OUTPUT\$file32).Hash.ToLower()
+	$checksum64 = (Get-FileHash $OUTPUT\$file64).Hash.ToLower()
+
+	$setVariables = @"
+`$version = "$version"
+`$checksum32 = "$checksum32"
+`$checksum64 = "$checksum64"
+"@
+
+	# Generate install script with correct variable values
+	$installScript = $template ` -Replace '::SET_VARIABLES::', $setVariables
+
+	Out-File -FilePath "$OUTPUT\chocolateyInstall.ps1" -InputObject $installScript -NoNewline
+}
+
+Function Write-NuSpec {
+	# Generate haxe.nuspec file
+	$nuspec = (Get-Content -Path "$SOURCE\haxe.nuspec" -Raw) -Replace '::VERSION::', $version
+	Out-File -FilePath "$OUTPUT\haxe.nuspec" -InputObject $nuspec -NoNewLine
+}
+
+Function Copy-Remaining {
+	# Copy over general files
+	$toCopy = @("$SOURCE\LICENSE.txt", "$SOURCE\VERIFICATION.txt")
+
+	ForEach ($item in $toCopy) {
+		Copy-File $item
+	}
+}
+
+Clear-Output
+Copy-Binaries
+Write-InstallScript
+Write-NuSpec
+Copy-Remaining

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Haxe Chocolatey Packaging Scripts
+
+This repository contains a script that can be used to generate the chocolatey package for Haxe.
+
+To generate the package, the zipped binaries need to be put in the root directory, as well as the `LICENSE.txt` file. They should be called `haxe-${version}-win.zip` and `haxe-${version}-win64.zip`, where `version` is the haxe version. For example, `haxe-4.2.4-win.zip` and `haxe-4.2.4-win64.zip`.
+
+The `Build-Package.ps1` script should be run in powershell to generate the package.
+
+Example usage:
+
+```powershell
+.\Build-Package -Version 4.2.4 # builds the package contents in the .\out directory
+.\Build-Package -Version 4.2.4 -Output C:\some\path # builds them into the specified directory
+```
+
+This prepares the package contents in the output directory, which can then be packaged by doing:
+
+```powershell
+cd .\out # or wherever the output is
+choco pack
+```

--- a/VERIFICATION.txt
+++ b/VERIFICATION.txt
@@ -1,3 +1,3 @@
 Packager (Andy Li) is a member of the Haxe Foundation.
- 
+
 The files included in this package are the "Windows Binaries" available at https://haxe.org/download/.

--- a/chocolateyInstall.ps1
+++ b/chocolateyInstall.ps1
@@ -1,11 +1,14 @@
+# set variables
+::SET_VARIABLES::
+
 $packDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 Install-ChocolateyZipPackage `
     -PackageName 'haxe' `
     -UnzipLocation "$packDir" `
-    -Url "$packDir\haxe-4.2.4-win.zip" `
-    -Checksum 'f14d000cc7ad1d8f6d399105cd6f4ceb4e23a9eea6ea046425bd3395188bdf2d' `
+    -Url "$packDir\haxe-$version-win.zip" `
+    -Checksum "$checksum32" `
     -ChecksumType 'sha256' `
-    -Url64bit "$packDir\haxe-4.2.4-win64.zip" `
-    -Checksum64 'cdbcec5fee9178a307e6bcbb436f8ff124dd2c18f86ad51e3d0a7a4ef489877a' `
+    -Url64bit "$packDir\haxe-$version-win64.zip" `
+    -Checksum64 "$checksum64" `
     -ChecksumType64 'sha256'

--- a/haxe.nuspec
+++ b/haxe.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>haxe</id>
-        <version>4.2.4</version>
+        <version>::VERSION::</version>
         <title>Haxe</title>
         <authors>Haxe Foundation</authors>
         <owners>Haxe Foundation</owners>
@@ -17,7 +17,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <summary>Haxe is an open source toolkit based on a modern, high level, strictly typed programming language, a cross-compiler, a complete cross-platform standard library and ways to access each platform's native capabilities.</summary>
         <description>Haxe is an open source toolkit based on a modern, high level, strictly typed programming language, a cross-compiler, a complete cross-platform standard library and ways to access each platform's native capabilities.
- 
+
 This package will install haxe and haxelib. After installation, you should run `haxelib setup %HAXELIB_PATH%;`, where `%HAXELIBPATH%` is the haxelib repository folder for placing third-party libraries. The folder should be created manually before running the command.</description>
         <releaseNotes>https://github.com/HaxeFoundation/haxe/blob/master/extra/CHANGES.txt</releaseNotes>
         <tags>haxe programming development foss cross-platform</tags>
@@ -26,8 +26,8 @@ This package will install haxe and haxelib. After installation, you should run `
         </dependencies>
     </metadata>
     <files>
-        <file src="haxe-*-win.zip" />
-        <file src="haxe-*-win64.zip" />
+        <file src="haxe-::VERSION::-win.zip" />
+        <file src="haxe-::VERSION::-win64.zip" />
         <file src="LICENSE.txt" />
         <file src="VERIFICATION.txt" />
         <file src="chocolateyInstall.ps1" />


### PR DESCRIPTION
The package files are now generated automatically using a script and put in the `out` folder.

No need to update them manually for each release now.